### PR TITLE
Improve guide

### DIFF
--- a/guide/configuration.html
+++ b/guide/configuration.html
@@ -61,7 +61,7 @@ title: Configuration
         <div>
           <div>
             <h3 class="title">
-            <a class="offset" id="muttrc-system"></a>1.1.&#160;Location of Mutt system config files</h3>
+            <a class="offset" id="muttrc-system"></a>1.1.&#160;Location of system config files</h3>
           </div>
         </div>
       </div>
@@ -153,7 +153,7 @@ title: Configuration
         <div>
           <div>
             <h3 class="title">
-            <a class="offset" id="muttrc-user"></a>1.2.&#160;Location of Mutt user config files</h3>
+            <a class="offset" id="muttrc-user"></a>1.2.&#160;Location of user config files</h3>
           </div>
         </div>
       </div>

--- a/guide/configuration.html
+++ b/guide/configuration.html
@@ -153,7 +153,7 @@ title: Configuration
         <div>
           <div>
             <h3 class="title">
-            <a class="offset" id="muttrc-user"></a>1.2.&#160;Location of Mutt system config files</h3>
+            <a class="offset" id="muttrc-user"></a>1.2.&#160;Location of Mutt user config files</h3>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This change improves some headlines in the guide a little bit. "system config files" was in two headlines, although the second is about user config files. Additionally in my opinion the "Mutt" is not needed (the page is about mutt)