### PR TITLE
Fix list items in newbie-tutorial's Mailing List Guidelines

### DIFF
--- a/_dev/newbie-tutorial.md
+++ b/_dev/newbie-tutorial.md
@@ -93,7 +93,8 @@ Discussions here are likely to be about:
 
 **Please:**
 
-- Send emails in plain text, not HTML Use an informative subject line
+- Send emails in plain text, not HTML
+- Use an informative subject line
 - Keep attachments small, or better still: link to the files
 - Remember that we're volunteers and we may take a while to reply
 


### PR DESCRIPTION
Fixes another little typo in the Mailing List Guidelines by splitting a line that should probably be two separate points.