### PR TITLE
build.md: Update and improve readability/usability

### DIFF
--- a/_dev/build.md
+++ b/_dev/build.md
@@ -13,18 +13,23 @@ See [Distro Pages](/distro.html).
 
 ## Obtain the Source
 
-Git, GitHub ZIP, Mutt tarball + NeoMutt patch
+The NeoMutt project is hosted on GitHub, so there are two main options to get
+the sources --- either as Git repository or GitHub archive file. A repository,
+not only for [GitHub users](/dev/newbie-tutorial#github), provides some
+benefits over a single release or snapshot archive, e.g. will empower you to
+work with the source code and contribute to the project more easily.
 
-### Git
+### Git <a class="offset" id="git"></a>
 
-Main branch: [neomutt](https://github.com/neomutt/neomutt/tree/master), **see also**:
-[list of branches](/dev/branches)
+Cloning the [main branch](https://github.com/neomutt/neomutt/tree/master) but
+also see our [list of branches](/dev/branches).
 
 ```
 git clone https://github.com/neomutt/neomutt
 ```
 
-Same as above but pointing to an other branch, e.g. `devel/autosetup`, for checkout.
+Same as above but pointing to an other branch, e.g. `devel/autosetup`, for
+checkout.
 
 ```
 git clone -b devel/autosetup https://github.com/neomutt/neomutt
@@ -44,44 +49,9 @@ Specific branch
 : <https://github.com/neomutt/neomutt/archive/devel/autosetup.zip>
 
 Note, archive file verification isn't possible here because this is not
-a NeoMutt release archive and thus no checksum file is available. Consider
-using Git (as mentioned [above](#git)) to clone a repository with the specific
-branch instead.
-
-### Mutt + NeoMutt Patch
-
-This is deprecated because **NeoMutt 2017-03-06 (1.8.0)** is the last release
-which offers separate patch/diff files for
-[Mutt](https://dev.mutt.org/trac/browser/?rev=6948%3Ad897983752f9) (version
-1.8.0 in this case).
-
-Mutt tarball
-: <ftp://ftp.mutt.org/pub/mutt/mutt-1.8.0.tar.gz>
-: <ftp://ftp.mutt.org/pub/mutt/mutt-1.8.0.tar.gz.asc>
-
-Grab, verify (assuming signing key is available) and extract the Mutt tarball.
-
-```
-curl -LR 'ftp://ftp.mutt.org/pub/mutt/mutt-1.8.0.tar.gz{,.asc}' --output 'mutt-1.8.0.tar.gz#1'
-gpg2 --verify mutt-1.8.0.tar.gz{.asc,}
-tar xzvf mutt-1.8.0.tar.gz
-```
-
-NeoMutt patch
-: <https://github.com/neomutt/neomutt/releases/tag/neomutt-20170306>
-
-Download the checksum and unified diff file and verify both. Afterwards
-apply the patch set in the root directory of extracted Mutt tarball.
-
-```
-GITHUB_URI='https://github.com/neomutt/neomutt/releases/download/neomutt-20170306'
-curl -LR ${GITHUB_URI}'/neomutt-20170306{.diff.gz,-CHECKSUM}' --output 'neomutt-20170306#1'
-unset -v GITHUB_URI
-gpg2 --verify neomutt-20170306-CHECKSUM
-sha256sum --check --ignore-missing neomutt-20170306-CHECKSUM
-gunzip --stdout neomutt-20170306.diff.gz | patch --unified --strip=1 --directory mutt-1.8.0/
-cd mutt-1.8.0/
-```
+a NeoMutt release archive and thus no checksum file is available. Consider to
+use Git instead (as mentioned [above](#git)) to clone the repository and
+checkout the specific branch afterwards.
 
 ## Autoreconf
 
@@ -107,26 +77,26 @@ List supported options to adapt or fine tune NeoMutt's build.
 
 ### Varied configure options
 
-| Category         | Option/Variable          | Description                                                   |
-| :--------------- | :----------------------- | :------------------------------------------------------------ |
-| General options  | `--prefix=PREFIX`        | Install architecture-independent files in PREFIX [/usr/local] |
-| Curses vs S-Lang | `--with-slang[=DIR]`     | Use *S-Lang* instead of *ncurses*                             |
-|                  | `--with-curses=DIR`      | Where *ncurses* is installed                                  |
-| Features         | `--enable-notmuch`       | Enable *Notmuch* support                                      |
-|                  | `--enable-gpgme`         | Enable *GPGME* support                                        |
-| Caching options  | `--enable-hcache`        | Enable header caching                                         |
-|                  | `--without-tokyocabinet` | Don't use *Tokyo Cabinet* even if it is available             |
-|                  | `--without-kyotocabinet` | Don't use *Kyoto Cabinet* even if it is available             |
-|                  | `--without-qdbm`         | Don't use *QDBM* even if it is available                      |
-|                  | `--without-gdbm`         | Don't use *GDBM* even if it is available                      |
-|                  | `--with-bdb[=DIR]`       | Use *Berkeley DB* for the header cache                        |
-|                  | `--with-lmdb[=DIR]`      | Use *LMDB* for the header cache                               |
-| Security         | `--with-gss[=PFX]`       | Compile in *GSSAPI* authentication for IMAP                   |
-|                  | `--with-ssl[=PFX]`       | Enable TLS support using *OpenSSL*                            |
-|                  | `--with-gnutls[=PFX]`    | Enable TLS support using *GnuTLS*                             |
-|                  | `--with-sasl[=PFX]`      | Use *SASL* network security library                           |
-| Debug options    | `--enable-debug`         | Enable debugging support                                      |
-|                  | `CFLAGS="-g -O0"`        | Set C compiler flags, e.g. for [GCC](https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html)             |
+| Category         | Option/Variable             | Description                                                   |
+| :--------------- | :-------------------------- | :------------------------------------------------------------ |
+| General          | `--prefix=PREFIX`           | Install architecture-independent files in PREFIX [/usr/local] |
+| Curses vs S-Lang | `--with-slang[=DIR]`        | Use [S-Lang][co_slng] instead of *ncurses*                    |
+|                  | `--with-curses=DIR`         | Where [ncurses][co_crss] is installed                         |
+| Features         | `--enable-notmuch`          | Enable [Notmuch](/feature/notmuch) support                    |
+|                  | `--enable-lua`              | Enable [Lua][co_lua] scripting support                        |
+|                  | `--enable-gpgme`            | Enable [GPGME][co_gpgme] support                              |
+| Header Caching   | `--with-gdbm[=DIR]`         | Use [GDBM][co_gdbm] for the header cache                      |
+|                  | `--with-tokyocabinet[=DIR]` | Use [Tokyo Cabinet][co_tcab] for the header cache             |
+|                  | `--with-kyotocabinet[=DIR]` | Use [Kyoto Cabinet][co_kcab] for the header cache             |
+|                  | `--with-qdbm[=DIR]`         | Use [QDBM][co_qdbm] for the header cache                      |
+|                  | `--with-bdb[=DIR]`          | Use [Berkeley DB][co_obdb] for the header cache               |
+|                  | `--with-lmdb[=DIR]`         | Use [LMDB][co_lmdb] for the header cache                      |
+| Security         | `--with-gss[=PFX]`          | Compile in [GSSAPI][co_gss2] authentication for IMAP          |
+|                  | `--with-ssl[=PFX]`          | Enable TLS support using [OpenSSL][co_ossl]                   |
+|                  | `--with-gnutls[=PFX]`       | Enable TLS support using [GnuTLS][co_gtls]                    |
+|                  | `--with-sasl[=PFX]`         | Use [SASL][co_sasl] network security library                  |
+| Debugging        | `--enable-debug`            | Enable debugging support                                      |
+|                  | `CFLAGS="-g -O0"`           | Set C compiler flags, e.g. for [GCC][co_dgcc]                 |
 
 ## Build
 
@@ -147,4 +117,21 @@ make install
 ```
 make uninstall
 ```
+
+
+[co_slng]:  <http://www.jedsoft.org/slang/>
+[co_crss]:  <https://www.gnu.org/software/ncurses/ncurses.html>
+[co_lua]:   <https://www.lua.org/>
+[co_gpgme]: <https://www.gnupg.org/related_software/gpgme/>
+[co_gdbm]:  <http://www.gnu.org.ua/software/gdbm/gdbm.html>
+[co_tcab]:  <http://fallabs.com/tokyocabinet/>
+[co_kcab]:  <http://fallabs.com/kyotocabinet/>
+[co_qdbm]:  <http://fallabs.com/qdbm/>
+[co_lmdb]:  <https://symas.com/lmdb/technical/>
+[co_gss2]:  <https://tools.ietf.org/html/rfc2744>
+[co_ossl]:  <https://www.openssl.org/>
+[co_gtls]:  <https://www.gnutls.org/>
+[co_sasl]:  <https://tools.ietf.org/html/rfc4422>
+[co_obdb]:  <http://www.oracle.com/technetwork/database/database-technologies/berkeleydb/overview/index.html>
+[co_dgcc]:  <https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html>
 

--- a/_dev/build.md
+++ b/_dev/build.md
@@ -14,7 +14,7 @@ See [Distro Pages](/distro.html).
 ## Obtain the Source
 
 The NeoMutt project is hosted on GitHub, so there are two main options to get
-the sources --- either as Git repository or GitHub archive file. A repository,
+the sources — either as Git repository or GitHub archive file. A repository,
 not only for [GitHub users](/dev/newbie-tutorial#github), provides some
 benefits over a single release or snapshot archive, e.g. will empower you to
 work with the source code and contribute to the project more easily.
@@ -100,7 +100,7 @@ List supported options to adapt or fine tune NeoMutt's build.
 
 ## Build
 
-Targets: neomutt, doc, ...
+Targets: neomutt, doc, …
 
 ```
 make
@@ -128,10 +128,10 @@ make uninstall
 [co_kcab]:  <http://fallabs.com/kyotocabinet/>
 [co_qdbm]:  <http://fallabs.com/qdbm/>
 [co_lmdb]:  <https://symas.com/lmdb/technical/>
-[co_gss2]:  <https://tools.ietf.org/html/rfc2744>
+[co_gss2]:  <https://en.wikipedia.org/wiki/Generic_Security_Services_Application_Program_Interface>
 [co_ossl]:  <https://www.openssl.org/>
 [co_gtls]:  <https://www.gnutls.org/>
-[co_sasl]:  <https://tools.ietf.org/html/rfc4422>
+[co_sasl]:  <https://en.wikipedia.org/wiki/Simple_Authentication_and_Security_Layer>
 [co_obdb]:  <http://www.oracle.com/technetwork/database/database-technologies/berkeleydb/overview/index.html>
 [co_dgcc]:  <https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html>
 

--- a/_dev/build.md
+++ b/_dev/build.md
@@ -2,109 +2,135 @@
 layout: concertina
 title: Building NeoMutt
 description: How to build NeoMutt from the Source Code
+status: wip
 ---
 
 # {{ page.title }}
 
 ## Install Dependencies
 
-see distro pages
+See [Distro Pages](/distro.html).
 
 ## Obtain the Source
 
-git, github zip, mutt tar + neo patch
+Git, GitHub ZIP, Mutt tarball + NeoMutt patch
 
 ### Git
 
-Main branch: neomutt
-
-see also: list of branches
+Main branch: [neomutt](https://github.com/neomutt/neomutt/tree/master), **see also**:
+[list of branches](/dev/branches)
 
 ```
 git clone https://github.com/neomutt/neomutt
 ```
 
-Other branch, e.g. devel/summary
+Same as above but pointing to an other branch, e.g. `devel/autosetup`, for checkout.
 
 ```
-git clone -b devel/summary https://github.com/neomutt/neomutt
+git clone -b devel/autosetup https://github.com/neomutt/neomutt
 ```
 
 ### GitHub
 
-latest release
-https://github.com/neomutt/neomutt/releases/latest
-select neomutt named file
+Latest release
+: <https://github.com/neomutt/neomutt/releases/latest>
 
-latest git
-https://github.com/neomutt/neomutt/archive/neomutt.zip
+Select a source package (Tar or ZIP archive) and the checksum file for
+download. **Important**, verify the tarball/ZIP archive file to ensure its
+integrity, see [Signing Code / Releases](/dev/signing#source-example) for an
+example.
 
-branch
-https://github.com/neomutt/neomutt/archive/devel/summary.zip
+Specific branch
+: <https://github.com/neomutt/neomutt/archive/devel/autosetup.zip>
+
+Note, archive file verification isn't possible here because this is not
+a NeoMutt release archive and thus no checksum file is available. Consider
+using Git (as mentioned [above](#git)) to clone a repository with the specific
+branch instead.
 
 ### Mutt + NeoMutt Patch
 
-ftp://ftp.mutt.org/pub/mutt/mutt-1.8.0.tar.gz
-https://github.com/neomutt/neomutt/releases/latest
-select neomutt patch
+This is deprecated because **NeoMutt 2017-03-06 (1.8.0)** is the last release
+which offers separate patch/diff files for
+[Mutt](https://dev.mutt.org/trac/browser/?rev=6948%3Ad897983752f9) (version
+1.8.0 in this case).
+
+Mutt tarball
+: <ftp://ftp.mutt.org/pub/mutt/mutt-1.8.0.tar.gz>
+: <ftp://ftp.mutt.org/pub/mutt/mutt-1.8.0.tar.gz.asc>
+
+Grab, verify (assuming signing key is available) and extract the Mutt tarball.
+
+```
+curl -LR 'ftp://ftp.mutt.org/pub/mutt/mutt-1.8.0.tar.gz{,.asc}' --output 'mutt-1.8.0.tar.gz#1'
+gpg2 --verify mutt-1.8.0.tar.gz{.asc,}
+tar xzvf mutt-1.8.0.tar.gz
+```
+
+NeoMutt patch
+: <https://github.com/neomutt/neomutt/releases/tag/neomutt-20170306>
+
+Download the checksum and unified diff file and verify both. Afterwards
+apply the patch set in the root directory of extracted Mutt tarball.
+
+```
+GITHUB_URI='https://github.com/neomutt/neomutt/releases/download/neomutt-20170306'
+curl -LR ${GITHUB_URI}'/neomutt-20170306{.diff.gz,-CHECKSUM}' --output 'neomutt-20170306#1'
+unset -v GITHUB_URI
+gpg2 --verify neomutt-20170306-CHECKSUM
+sha256sum --check --ignore-missing neomutt-20170306-CHECKSUM
+gunzip --stdout neomutt-20170306.diff.gz | patch --unified --strip=1 --directory mutt-1.8.0/
+cd mutt-1.8.0/
+```
 
 ## Autoreconf
 
-Generate the appropriate configuration and build scripts
+Generate the appropriate configuration and build scripts.
 
 ```
-autoreconf -i                     
-configure.ac:17: installing './compile'
-configure.ac:21: installing './config.guess'
-configure.ac:21: installing './config.sub'
-configure.ac:12: installing './install-sh'
-configure.ac:12: installing './missing'
-Makefile.am: installing './depcomp'
+autoreconf -i
+configure.ac:19: installing '.build-aux/compile'
+configure.ac:23: installing '.build-aux/config.guess'
+configure.ac:23: installing '.build-aux/config.sub'
+configure.ac:10: installing '.build-aux/install-sh'
+configure.ac:10: installing '.build-aux/missing'
+Makefile.am: installing '.build-aux/depcomp'
 ```
 
 ## Configure
 
+List supported options to adapt or fine tune NeoMutt's build.
+
+```
 ./configure --help
+```
 
-### General options
+### Varied configure options
 
-  --prefix=/usr/local
-
-### Curses vs Slang
-
-  --with-slang[=DIR]      Use S-Lang instead of ncurses
-  --with-curses=DIR       Where ncurses is installed
-
-### Features
-
-  --enable-notmuch        Enable NOTMUCH support
-  --enable-gpgme          Enable GPGME support
-
-### Caching Options
-
-  --enable-hcache         Enable header caching
-  --without-tokyocabinet  Don't use tokyocabinet even if it is available
-  --without-kyotocabinet  Don't use kyotocabinet even if it is available
-  --without-qdbm          Don't use qdbm even if it is available
-  --without-gdbm          Don't use gdbm even if it is available
-  --with-bdb[=DIR]        Use BerkeleyDB4 if gdbm is not available
-  --with-lmdb[=DIR]       Use LMDB if gdbm is not available
-
-### Security
-
-  --with-gss[=PFX]        Compile in GSSAPI authentication for IMAP
-  --with-ssl[=PFX]        Enable TLS support using OpenSSL
-  --with-gnutls[=PFX]     enable TLS support using gnutls
-  --with-sasl[=PFX]       Use SASL network security library
-
-### Debug Options
-
-  --enable-debug          Enable debugging support
-	CFLAGS="-g -O0"
+| Category         | Option/Variable          | Description                                                   |
+| :--------------- | :----------------------- | :------------------------------------------------------------ |
+| General options  | `--prefix=PREFIX`        | Install architecture-independent files in PREFIX [/usr/local] |
+| Curses vs S-Lang | `--with-slang[=DIR]`     | Use *S-Lang* instead of *ncurses*                             |
+|                  | `--with-curses=DIR`      | Where *ncurses* is installed                                  |
+| Features         | `--enable-notmuch`       | Enable *Notmuch* support                                      |
+|                  | `--enable-gpgme`         | Enable *GPGME* support                                        |
+| Caching options  | `--enable-hcache`        | Enable header caching                                         |
+|                  | `--without-tokyocabinet` | Don't use *Tokyo Cabinet* even if it is available             |
+|                  | `--without-kyotocabinet` | Don't use *Kyoto Cabinet* even if it is available             |
+|                  | `--without-qdbm`         | Don't use *QDBM* even if it is available                      |
+|                  | `--without-gdbm`         | Don't use *GDBM* even if it is available                      |
+|                  | `--with-bdb[=DIR]`       | Use *Berkeley DB* for the header cache                        |
+|                  | `--with-lmdb[=DIR]`      | Use *LMDB* for the header cache                               |
+| Security         | `--with-gss[=PFX]`       | Compile in *GSSAPI* authentication for IMAP                   |
+|                  | `--with-ssl[=PFX]`       | Enable TLS support using *OpenSSL*                            |
+|                  | `--with-gnutls[=PFX]`    | Enable TLS support using *GnuTLS*                             |
+|                  | `--with-sasl[=PFX]`      | Use *SASL* network security library                           |
+| Debug options    | `--enable-debug`         | Enable debugging support                                      |
+|                  | `CFLAGS="-g -O0"`        | Set C compiler flags, e.g. for [GCC](https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html)             |
 
 ## Build
 
-targets: mutt, docs, validate
+Targets: neomutt, doc, ...
 
 ```
 make

--- a/_dev/newbie-tutorial.md
+++ b/_dev/newbie-tutorial.md
@@ -98,7 +98,7 @@ Bugs, Features, Code, Distros, Enhancements, Git
 - Keep attachments small, or better still: link to the files
 - Remember that we're volunteers and we may take a while to reply
 
-## GitHub
+## GitHub <a class="offset" id="github"></a>
 
 If you're a GitHub user, there are lots of ways to keep informed about NeoMutt
 development.

--- a/_dev/signing.md
+++ b/_dev/signing.md
@@ -13,7 +13,7 @@ All **release commits** in git are signed and all **GitHub downloads** come with
 
 ## Keys
 
-The NeoMutt signing key is: 
+The NeoMutt signing key is:
 - `86C2397270DD7A561263CA4E5FAF0A6EE7371805`
 - Richard Russon (NeoMutt) <rich@flatcap.org>
 
@@ -38,7 +38,7 @@ This confirms that the release matches the NeoMutt signing key.
 ```sh
 git clone https://github.com/neomutt/neomutt
 cd neomutt
-git 
+git
 git tag -v neomutt-20170428
 ```
 
@@ -58,7 +58,7 @@ git checkout -b neomutt-20170428
 # build
 ```
 
-## Source Example
+## Source Example <a class="offset" id="source-example"></a>
 
 Download a source package and the CHECKSUM file from the [release page](https://github.com/neomutt/neomutt/releases/latest)
 
@@ -66,7 +66,7 @@ Download a source package and the CHECKSUM file from the [release page](https://
 wget https://github.com/neomutt/neomutt/archive/neomutt-20170428.tar.gz
 wget https://github.com/neomutt/neomutt/releases/download/neomutt-20170428/neomutt-20170428-CHECKSUM
 
-gpg2 --verify neomutt-20170428-CHECKSUM 
+gpg2 --verify neomutt-20170428-CHECKSUM
 ```
 
 ```reply
@@ -75,7 +75,7 @@ gpg: Good signature from "Richard Russon (NeoMutt) <rich@flatcap.org>" [ultimate
 ```
 
 ```sh
-sha256sum -c neomutt-20170428-CHECKSUM 
+sha256sum -c neomutt-20170428-CHECKSUM
 ```
 
 ```reply


### PR DESCRIPTION
The [Building NeoMutt](https://www.neomutt.org/dev/build) page could be more interactive and easier to read.
Therefore I will propose my work on this.

Main changes:
- reformat to avoid concatenated lines in resulting web page
- protect long command option dashes to avoid ‘--’ to ‘—’ conversion
- fixing several case insensitivity of proper names and acronyms
- combine multiple configure subsections into one table
- convert different text passages and URIs into clickable links
- add additionally links for further reading and information
- add hopefully correct annotations <sup>[[1]](#fn1)</sup> to workflow examples
- add status WIP due to upcoming autosetup build system transition

<a name="fn1"><sup>[1]</sup></a> because I'm not a developer

Regards