### PR TITLE
Fix typo in release notes

### DIFF
--- a/_posts/2017-12-15-release.md
+++ b/_posts/2017-12-15-release.md
@@ -9,4 +9,4 @@ title: Release 2017-12-15
 Unfortunately, the previous release introduced a couple of annoying bugs into NeoMutt.
 Sorry, everyone.
 
-See release [2017-08-12](https://www.neomutt.org/2017/12/08/release) for the recent changes.
+See release [2017-12-08](https://www.neomutt.org/2017/12/08/release) for the recent changes.


### PR DESCRIPTION
@flatcap Our convention for date is YYYY-MM-DD, right?