### PR TITLE
Update debugging page

### DIFF
--- a/_dev/debug.md
+++ b/_dev/debug.md
@@ -40,6 +40,11 @@ make EXTRA_CFLAGS=-g
 ```
 cgdb neomutt
 ```
+or, if you do not have `cgdb`, you can give the Text User Interface (TUI) of `gdb` a try:
+
+```shell
+gdb -tui neomutt
+```
 
 ## Attaching a debugger to NeoMutt
 

--- a/_dev/debug.md
+++ b/_dev/debug.md
@@ -11,6 +11,7 @@ When things needs further investigation
 ## Available procedures
 
 - Logging
+- Compile with debugging information
 - Starting NeoMutt in a debugger, e.g. [cgdb](https://cgdb.github.io/)
 - Attaching a debugger to NeoMutt
 - Debugging a coredump
@@ -23,6 +24,15 @@ mutt -d 5
 
 ```
 tail -F ~/.muttdebug0
+```
+
+## Compile with debugging information
+
+You can compile NeoMutt with debugging information.
+Follow the guidelines on how to compile NeoMutt according to your distribution, and when executing make, pass the `-g` flag:
+
+```shell
+make EXTRA_CFLAGS=-g
 ```
 
 ## Starting NeoMutt in a debugger


### PR DESCRIPTION
Hello,

just two minor additions to the debug page:

 - how to compile with debug info
 - mention alternative TUI to cgdb provided by gdb