### PR TITLE
Replace OpenSUSE with openSUSE in release notes

### DIFF
--- a/_posts/2018-02-23-release.md
+++ b/_posts/2018-02-23-release.md
@@ -44,7 +44,7 @@ and our **regular contributors**:
 - browser: `<goto-parent>` function bound to `p`
 - editor: `<history-search>` function bound to `Ctrl-r`
 - Cygwin support: https://www.neomutt.org/distro/cygwin
-- OpenSUSE support: https://www.neomutt.org/distro/suse
+- openSUSE support: https://www.neomutt.org/distro/suse
 - Upstream Homebrew support: Very soon - https://www.neomutt.org/distro/homebrew
 
 ## Bug Fixes
@@ -66,7 +66,7 @@ and our **regular contributors**:
 ## Website
 
 - Installation guide for Cygwin
-- Installation guide for OpenSUSE
+- Installation guide for openSUSE
 - Installation guide for CRUX
 
 ## Build


### PR DESCRIPTION
I'm submitting it as a second patch instead of merging it with #62 because you might don't want to change release notes after they are published.

Cheers!