### PR TITLE
Add page about static analysis

### DIFF
--- a/_dev/analysis.md
+++ b/_dev/analysis.md
@@ -1,0 +1,37 @@
+---
+layout: concertina
+title: Analyze NeoMutt
+description: Static analysis of NeoMutt's code
+---
+
+# {{ page.title }}
+
+[Wikipedia](https://en.wikipedia.org/wiki/List_of_tools_for_static_code_analysis#C,_C++) has a nice list of static analyzers for C source code.
+Those can be used to find bugs without compiling, executing and debugging neomutt.
+
+## CppCheck
+
+Since NeoMutt's code base is relatively big, it is easier to execute [CppCheck](cppcheck.sourceforge.net) from the command line and let it save its analysis to an output file.
+
+CppCheck is available on all major platforms, so it can probably be installed through the package manager of your system.
+In case you are using Windows (but not Cygwin) it is possible to download the installer from the website.
+We can use `cppcheck-gui` afterwards for filtering the warnings we want to analyze.
+
+You can use following command for analyzing the source code
+
+```
+cppcheck --enable=all --language=c --std=c99 -i autosetup --platform=unspecified -D_POSIX_PATH_MAX=4096 -DPATH_MAX=2048 -I/usr/include -I/usr/include/mit-krb5 -I. --output-file=cppcheck.xml --xml --xml-version=2 <path to neomutt source code directory>
+```
+
+A complete description of all parameters can be found through `man cppcheck` or `cppcheck --help`.
+Some considerations:
+
+- `--enable-all --output-file=<filename> --xml --xml-version=2` collect as many warning as possible and save them to a file, in order to view them later with `cppcheck-gui`
+- `--platform=unspecified` do not restrict the analysis to a 32 or 64 bit platform
+- `--language=c --std=c99` NeoMutt follows this standard
+- `-D_POSIX_PATH_MAX=4096 -DPATH_MAX=2048` can be left out, but CppCheck may warn that it does not know the values for those macros. Since most of the time the actual values are not relevant, you might just set them to two numeric values.
+- `-i autosetup` for excluding the `autosetup` directory
+- `-I<path>` where to find include files
+
+If cppcheck takes too much time for analyzing the source code, it is always possible to analyze only specific files, tell it to test less macro combinations, or to not enable all warnings.
+


### PR DESCRIPTION
I have a list of static analyzers on my PC (clang-tidy, flawfinder, vera++, pstack, splint), but I have no idea how useful they can be.
CppCheck is the only tool I use regularly.
 
Maybe next week I can see which of those are in the repository and see how they behave on Neomutt's code.