### PR TITLE
Adds link to Xterm color listing

### DIFF
--- a/guide/configuration.html
+++ b/guide/configuration.html
@@ -1427,7 +1427,7 @@ folder-hook work "set sort=threads"
       <code class="literal">green</code>,
       <code class="literal">blue</code>, or by their number in the palette, such as
       <code class="literal">color12</code>,
-      <code class="literal">color207</code>(the palette consists of 256 colors).</p>
+      <code class="literal">color207</code> (the palette consists of the 256 Xterm colors; see <a href="https://web.archive.org/web/20190712111427/https://jonasjacek.github.io/colors/">here</a> for a listing of all the colors in the palette).</p>
       <p>Named colours may also be prefixed by a
       <span class="emphasis">
         <em>modifier</em>


### PR DESCRIPTION
I had a hard time understanding what `color23` meant. These are actually Xterm colors and neomutt does not generate them on its own. I added a link to a listing of all the colors for easy reference.