### PR TITLE
Update debian.md

### DIFF
--- a/_distro/debian.md
+++ b/_distro/debian.md
@@ -15,9 +15,6 @@ Maintainers: [Antonio Radici, Faidon Liambotis](email:pkg-mutt-maintainers@lists
 
 Debian, Ubuntu
 
-Currently in Testing. Note, that there's currently no plain Mutt package
-available in Debian testing, because it was substituted with NeoMutt.
-
 ## Installation <a id="install"></a>
 
 ```reply


### PR DESCRIPTION
Based on a discussion with  pippobaldo[m] on #neomutt IRC.

Remove statements about:
- neomutt being in testing. It's not present in debian testing now.
- absence of plain mutt package. It's not true anymore.