### PR TITLE
global-hooks: fix description for shutdown-hook

### DIFF
--- a/_feature/global-hooks.html
+++ b/_feature/global-hooks.html
@@ -115,7 +115,7 @@ startup-hook 'echo `action.sh ARGS`'
       <span class="bold">
         <strong>Since:</strong>
       </span>NeoMutt 2016-11-25</p>
-      <p>This feature implements a hook that is called when NeoMutt shuts down, but before closing the first mailbox. This is most likely to be useful to users of
+      <p>This feature implements a hook that is called when NeoMutt shuts down, but before closing the last mailbox. This is most likely to be useful to users of
       <a class="link" href="/feature/notmuch" title="Notmuch Feature">notmuch</a>.</p>
     </div>
   </div>


### PR DESCRIPTION
_feature/global-hooks: fix description for shutdown-hook

Descriptions for shutdown-hook seem to contradict each other.
Please feel free to correct me if I'm wrong about it.