### PR TITLE
Fix broken link in dev/changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'jekyll'
 
 group :jekyll_plugins do
+  gem 'github-pages'
   gem 'jekyll-algolia'
   gem 'jekyll-sitemap'
   gem 'jekyll-mentions'

--- a/changes/devel.md
+++ b/changes/devel.md
@@ -273,7 +273,7 @@ The new NeoMutt documentation:
 | File                                                                                                           | Description                          |
 | :------------------------------------------------------------------------------------------------------------- | :----------------------------------- |
 | [README.md](https://github.com/neomutt/neomutt/blob/master/README.md)                                          | An Introduction to NeoMutt           |
-| [CONTRIBUTING.md](https://github.com/neomutt/neomutt/blob/master/CONTRIBUTING.md)                              | How to start contributing to NeoMutt |
+| [Development Newbie Tutorial](/dev/newbie-tutorial)                          | How to start contributing to NeoMutt |
 | [bug-report.md](https://github.com/neomutt/neomutt/blob/master/.github/ISSUE_TEMPLATE/bug-report.md)           | How to write a perfect bug report    |
 | [feature-request.md](https://github.com/neomutt/neomutt/blob/master/.github/ISSUE_TEMPLATE/feature-request.md) | w to write a perfect feature request |
 | [question.md](https://github.com/neomutt/neomutt/blob/master/.github/ISSUE_TEMPLATE/question.md)               | How to ask a perfect question        |


### PR DESCRIPTION
This addresses #97 and
- fixes the broken link, now points to /dev/newbie-tutorial
- add github-pages gem for easy local setup of jekyll site