### PR TITLE
fix link to sample.neomuttrc-starter

### DIFF
--- a/guide/configuration.html
+++ b/guide/configuration.html
@@ -286,7 +286,7 @@ title: Configuration
       <em>meant</em>
     </span>to be customized to your needs and preferences. However, this configurability can make it difficult when just getting started. A few sample neomuttrc files come with NeoMutt, under
     <code class="literal">doc/neomutt/samples/</code>. Among them,
-    <a class="ulink" href="https://github.com/neomutt/neomutt/blob/master/contrib/sample.neomuttrc-starter" target="_top">sample.neomuttrc-starter</a> is a basic example config with a few suggested settings and pointers to useful programs.</p>
+    <a class="ulink" href="https://github.com/neomutt/neomutt/blob/master/contrib/samples/sample.neomuttrc-starter" target="_top">sample.neomuttrc-starter</a> is a basic example config with a few suggested settings and pointers to useful programs.</p>
   </div>
   <div class="sect1">
     <div class="titlepage">


### PR DESCRIPTION
It looks like the file has moved. I just wanted to get started with neomutt and ran into it. :)