### PR TITLE
Update and correct color scheme links

### DIFF
--- a/_contrib/colorschemes.md
+++ b/_contrib/colorschemes.md
@@ -9,10 +9,10 @@ dir: colorschemes
 
 ## Some colorschemes for NeoMutt
 
-- [neonwolf](https://github.com/h3xx/mutt-colors-neonwolf)
+- [neonwolf](https://codeberg.org/h3xx/mutt-colors-neonwolf)
 - [256](https://github.com/d3ckard/mutt_color_themes)
 - [solarized](https://github.com/altercation/mutt-colors-solarized)
-- [solarized-dark](https://github.com/neomutt/neomutt/blob/main/data/colorschemes/solarized-dark.neomuttrc)
+- [solarized-dark-256](https://github.com/neomutt/neomutt/blob/main/data/colorschemes/solarized-dark-256.neomuttrc)
 - [gruvbox](https://www.sthu.org/code/codesnippets/mutt-gruvbox.html)
 - [neonwolf-256](https://github.com/neomutt/neomutt/blob/main/data/colorschemes/neonwolf-256.neomuttrc)
 - [vombatidae](https://github.com/neomutt/neomutt/blob/main/data/colorschemes/vombatidae.neomuttrc)


### PR DESCRIPTION
- https://github.com/h3xx/mutt-colors-neonwolf is moved to https://codeberg.org/h3xx/mutt-colors-neonwolf
- https://github.com/neomutt/neomutt/blob/main/data/colorschemes/solarized-dark.neomuttrc is not found, I suppose it is https://github.com/neomutt/neomutt/blob/main/data/colorschemes/solarized-dark-256.neomuttrc