### PR TITLE
guide: The section for `tmpdir` is incorrectly named `tmp_dir`

### DIFF
--- a/guide/reference.html
+++ b/guide/reference.html
@@ -13175,7 +13175,7 @@ set ssl_ca_certificates_file=/etc/ssl/certs/ca-certificates.crt
         <div>
           <div>
             <h3 class="title">
-            <a id="tmpdir"></a>3.506.&#160;tmp_dir</h3>
+            <a id="tmpdir"></a>3.506.&#160;tmpdir</h3>
           </div>
         </div>
       </div>


### PR DESCRIPTION
It's just a redirection to the renamed setting variable `tmp_dir` but for some reason the title got generated wrong.

I know the getting started guide should be generated from the neomutt repo but I couldn't figure out where the misgeneration comes from. I believe the `tmp_dir` setting documentation comes from `docs/config.c`, while the rename for `tmpdir` comes from `mutt_config.c` but that file seems to contain the correct names in the correct places.