### PR TITLE
site: Expand information on documentation sources

### DIFF
--- a/site.md
+++ b/site.md
@@ -23,7 +23,25 @@ framework and a colour scheme from Ian Wootten's
 [jekyll-syntax](https://github.com/iwootten/jekyll-syntax) collection.
 
 - Source Code for this site:  
-  [https://github.com/neomutt/neomutt.github.io](https://github.com/neomutt/neomutt.github.io)
+  [NeoMutt Pages repository](https://github.com/neomutt/neomutt.github.io)
+  Some pages are generated from files in the [NeoMutt source repository](https://github.com/neomutt/neomutt).
+
+    - The NeoMutt Guide is generated from [docs/manual.xml.head](https://github.com/neomutt/neomutt/blob/main/docs/manual.xml.head)
+      It is written in DocBook (XML). The Reference section is generated from
+      [docs/config.c](https://github.com/neomutt/neomutt/blob/main/docs/config.c)
+      and renamed feature notes come from [mutt_config.c](https://github.com/neomutt/neomutt/blob/main/mutt_config.c).
+
+    - The Features pages are generated from a subset of the same file.
+      Look for the `<sect1>` headings: `<sect1 id="account-cmd"> until <sect1 id="use-threads-feature">`
+
+    - The Man pages are generated from separate files in the docs directory:
+      - [docs/mbox.5](https://github.com/neomutt/neomutt/blob/main/docs/mbox.5)
+      - [docs/mmdf.5](https://github.com/neomutt/neomutt/blob/main/docs/mmdf.5)
+      - [docs/neomutt.man](https://github.com/neomutt/neomutt/blob/main/docs/neomutt.man)
+      - [docs/neomuttrc.man.head](https://github.com/neomutt/neomutt/blob/main/docs/neomuttrc.man.head)
+      - [docs/pgpewrap.1](https://github.com/neomutt/neomutt/blob/main/docs/pgpewrap.1)
+      - [docs/smime_keys.1](https://github.com/neomutt/neomutt/blob/main/docs/smime_keys.1)
+
 - NeoMutt Releases:  
   [https://github.com/neomutt/neomutt/releases/latest](https://github.com/neomutt/neomutt/releases/latest)
 - Questions/Bugs with the website:  


### PR DESCRIPTION
Detailed information on where to find the sources for the documentation stimulates contributions.

As promised in #117, I expanded the info on the doc sources. I believe nested lists shouldn't be a problem but I don't know how to generate a preview to check.