### PR TITLE
distro.md: make repology badge display 3 columns

### DIFF
--- a/distro.md
+++ b/distro.md
@@ -44,4 +44,4 @@ table row).
   </tbody>
 </table>
 
-<a href="https://repology.org/project/neomutt/versions"><img src="https://repology.org/badge/vertical-allrepos/neomutt.svg"></a>
+<a href="https://repology.org/project/neomutt/versions"><img src="https://repology.org/badge/vertical-allrepos/neomutt.svg?columns=3"></a>


### PR DESCRIPTION
This is a cosmetic fix

Preview: https://github.com/luzpaz/neomutt.github.io/blob/repology-3-column/distro.md