### PR TITLE
Add link to ayu-dark-256 colorscheme

### DIFF
--- a/_contrib/colorschemes.md
+++ b/_contrib/colorschemes.md
@@ -17,6 +17,7 @@ dir: colorschemes
 - [neonwolf-256](https://github.com/neomutt/neomutt/blob/main/data/colorschemes/neonwolf-256.neomuttrc)
 - [vombatidae](https://github.com/neomutt/neomutt/blob/main/data/colorschemes/vombatidae.neomuttrc)
 - [zenburn](https://github.com/neomutt/neomutt/blob/main/data/colorschemes/zenburn.neomuttrc)
+- [ayu-dark-256](https://github.com/neomutt/neomutt/blob/main/data/colorschemes/ayu-dark-256.neomuttrc)
 
 Welcome to add more!
 


### PR DESCRIPTION
**What does this PR do?**
Adds an entry for the recently added `ayu-dark-256 colorscheme` into `colorschemes.md` file.