### PR TITLE
Add 'midnight' to the list of useful programs

### DIFF
--- a/_contrib/useful-programs.md
+++ b/_contrib/useful-programs.md
@@ -35,6 +35,9 @@ status: stable
   in a maildir with the labels synchronized with a notmuch database.
   The changes to tags in the notmuch database may be pushed back remotely
   to your GMail account.
+* [midnight](https://crates.io/crates/midnight) -- a sendmail agnostic
+  "send later" program. Requires [at(1)](https://linux.die.net/man/1/at)
+  as a runtime dependency.
 
 ## Address books
 


### PR DESCRIPTION
Add a new program--[midnight](https://crates.io/crates/midnight)--to the contrib/useful-prgrams page. Midnight is a small suite of rust applications which wrap a batch processing program called [at(1)](https://linux.die.net/man/1/at), and allows users to schedule mail for delivery at a later date/time.

I think it makes sense to add this under the 'Mail downloading and sending' section, but if this should under 'Miscellaneous', just let me know and I'll get it updated.

Cheers!

See discussion: https://github.com/neomutt/neomutt/discussions/4207#discussioncomment-15450572