### PR TITLE
docs: fix swapped descriptions for %{limit-pattern} and %{version}

### DIFF
--- a/_man/neomuttrc.html
+++ b/_man/neomuttrc.html
@@ -18390,7 +18390,7 @@ Default: "-*%A"
                       <em>%{limit-pattern}</em>
                     </span>
                   </td>
-                  <td align="left">NeoMutt version string</td>
+                  <td align="left">Currently active limit pattern, if any</td>
                 </tr>
                 <tr>
                   <td align="left">
@@ -18403,7 +18403,7 @@ Default: "-*%A"
                       <em>%{version}</em>
                     </span>
                   </td>
-                  <td align="left">Currently active limit pattern, if any</td>
+                  <td align="left">NeoMutt version string</td>
                 </tr>
                 <tr>
                   <td align="left">

--- a/guide/reference.html
+++ b/guide/reference.html
@@ -15863,7 +15863,7 @@ set ssl_ca_certificates_file=/etc/ssl/certs/ca-certificates.crt
               <td>
                 <code class="literal">%{limit-pattern}</code>
               </td>
-              <td>NeoMutt version string</td>
+              <td>Currently active limit pattern, if any</td>
             </tr>
             <tr>
               <td>
@@ -15872,7 +15872,7 @@ set ssl_ca_certificates_file=/etc/ssl/certs/ca-certificates.crt
               <td>
                 <code class="literal">%{version}</code>
               </td>
-              <td>Currently active limit pattern, if any</td>
+              <td>NeoMutt version string</td>
             </tr>
             <tr>
               <td>


### PR DESCRIPTION
The descriptions for %{limit-pattern} and %{version} were swapped in both guide/reference.html and _man/neomuttrc.html, causing %{limit-pattern} to be labeled as "NeoMutt version string" and %{version} as "Currently active limit pattern, if any".