### PR TITLE
docs: point to current architecture pages, not the archived arch repo

### DIFF
--- a/_dev/roadmap/hard-problems.md
+++ b/_dev/roadmap/hard-problems.md
@@ -30,10 +30,10 @@ and describe your thoughts.
 
 For some ideas, please see:
 
-* [plans for refactoring Mutt's code](https://github.com/neomutt/neomutt/issues/310)
+* [plans for refactoring Mutt's code](https://github.com/neomutt/neomutt/issues/310) (closed 2017, historical context)
 * [(Re-)Building the Documentation](http://mailman.neomutt.org/pipermail/neomutt-devel-neomutt.org/2017-June/000438.html)
 * [topic:testing issues](https://github.com/neomutt/neomutt/labels/topic%3Atesting)
-* [architecture repository](https://github.com/neomutt/arch#arch)
+* [Event-Driven NeoMutt](/dev/roadmap/event-neomutt) and [Event-Driven Sidebar](/dev/roadmap/event-sidebar) — the current architecture design (the old [architecture repository](https://github.com/neomutt/arch#arch) has been archived since 2023)
 * [Our complicated build process](https://neomutt.org/dev/build/make)
 
 ### Difficult to implement features


### PR DESCRIPTION
## Summary

`hard-problems.md`'s "Refactoring the code" section links to `neomutt/arch` as "the architecture repository", but that repo has been archived since 2023-12-12. This site's own `event-neomutt.md` and `event-sidebar.md` pages already contain a detailed, current architecture description (nested Data/Windows/Views/Notifications model), but weren't linked from here.

Also marked issue #310 ("plans for refactoring Mutt's code") as closed/historical — it's been closed since 2017-11 and was presented as a live pointer for ideas.

## Note

I've sent a subscribe request to neomutt-devel and posted an introduction (asking about issue #4398's status separately), but haven't had a response yet. Opening this doc fix now since it's small and self-contained; happy to hold or amend based on any list feedback.

## Not verified

I don't have a local Jekyll/Ruby toolchain set up, so I haven't rendered the site to confirm the internal link paths (`/dev/roadmap/event-neomutt`, `/dev/roadmap/event-sidebar`) resolve correctly — inferred from `_includes/roadmap-links.html`'s URL handling, but please check.