### PR TITLE
docs: fix broken "Discussions" link label

### DIFF
--- a/index.md
+++ b/index.md
@@ -59,11 +59,11 @@ Are you a fluent speaker of a language, other than English?
 
 You could help our translation effort.  It's simple to do and would benefit so many people.
 
-### [Discussions](https://github.com/neomutt/neomutt/issues?q=is:issue+is:open+sort:updated-desc+label:status:discuss)
+### [Discussions](https://github.com/neomutt/neomutt/issues?q=is:issue+is:open+sort:updated-desc+label:type:discuss)
 
 When developing new features, the developers would love to benefit from your experience.
 
-If an issue is labelled "status:discuss", then you're encouraged to offer your thoughts and opinions.
+If an issue is labelled "type:discuss", then you're encouraged to offer your thoughts and opinions.
 
 ### [Donation](https://www.paypal.me/russon/)
 


### PR DESCRIPTION
index.md's "Discussions" link (under "I want to help NeoMutt") points to an issue search filtered by label:status:discuss, but that label doesn't exist on this repo. Confirmed via the GitHub API: the real label is type:discuss, currently on 54 open issues; searching for status:discuss returns zero. Fixed by changing both occurrences of status:discuss to type:discuss.

Verified with: `gh api repos/neomutt/neomutt/labels` (confirms type:discuss exists, status:discuss does not) and `gh api "search/issues?q=repo:neomutt/neomutt+is:issue+is:open+label:type:discuss"` (54 results with the corrected label).