### PR TITLE
docs: fix stale "Scripting" wishlist item in about.md

### DIFF
--- a/about.md
+++ b/about.md
@@ -125,9 +125,10 @@ Below is a list of areas we'd like to work on:
 
 ### Scripting
 
-- NeoMutt could be so much more powerful if it had scripting capability.
-  A possible candidate is [LUA](https://www.lua.org/), which is
-  small, simple, but powerful.
+- NeoMutt already has [Lua](/feature/lua) scripting support, but it's
+  still limited: there's no way to interact with Mailboxes or Emails
+  directly. Expanding the API to expose these would make it much more
+  useful.
 
 ### Upstream
 


### PR DESCRIPTION
about.md's "What's next?" section described Lua scripting as a hypothetical future candidate ("NeoMutt could be so much more powerful if it had scripting capability... A possible candidate is LUA"), but Lua shipped in 2017-04 and is listed as a stable feature on feature.md.

Reworded to reflect reality: Lua is shipped, now links to /feature/lua, and the bullet names the actual remaining gap (no Mailbox/Email API access) per _feature/lua.html's own Limitations section, which already flags this as planned future work -- so the item still belongs on the "what's next" list, just accurately described.