### PR TITLE
docs: restore Contrib and Devel links to the desktop nav

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -37,9 +37,8 @@
               <ul class="nav navbar-nav">
                   <li class="active"><a class="nav-link" href="/news">News</a></li>
                   <li class="active"><a class="nav-link" href="/feature">Features</a></li>
-                  <!-- <li class="active"><a class="nav-link" href="/contrib">Contrib</a></li> -->
-
-                  <!-- <li class="active"><a class="nav-link" href="/dev">Devel</a></li> -->
+                  <li class="active"><a class="nav-link" href="/contrib">Contrib</a></li>
+                  <li class="active"><a class="nav-link" href="/dev">Devel</a></li>
                   <li class="active"><a class="nav-link" href="/distro">Downloads</a></li>
                   <li class="active visible-xs-block"><a class="nav-link" href="/links">Links</a></li>
 


### PR DESCRIPTION
Both were commented out of the desktop navbar (_includes/header.html) in commit eab2af9 (2017-10-18, "add algolia search") as an incidental side effect of making room for the new search box -- the commit message never mentions removing nav items, and Downloads (commented out in the same commit) was later deliberately restored in e9c388f. Contrib and Devel were left commented out and never revisited since.

Both pages remain live and actively maintained: contrib.md is a populated user-contributions table, dev.md links the newbie tutorial, CI status and roadmap. The mobile-only sidebar (links.html) already includes both, so desktop users have been missing links mobile users still get -- an unintentional gap, not a deliberate design choice.

AI disclosure: found and implemented with Claude Code's assistance while auditing the site's navigation, reviewed and sent by me.