### PR TITLE
docs: clarify OAuth2 roadmap entry vs. existing external-script support

### DIFF
--- a/_dev/roadmap/roadmap.md
+++ b/_dev/roadmap/roadmap.md
@@ -116,6 +116,11 @@ transparency.
 **Description**: Support OAuth2 Authentication  
 **Status**: Future
 
+NeoMutt already has preliminary OAuth2 support for IMAP, POP and SMTP via
+external scripts -- see [OAUTHBEARER and XOAUTH2 Support](/guide/optionalfeatures.html#oauth).
+This entry tracks a more complete, native implementation, where NeoMutt
+itself manages the token flow.
+
 Supporting OAuth2 doesn't require many changes to NeoMutt.
 Initially, NeoMutt would ask the server for a token and get the user to
 visit the server's website.  This saved token can then be used to login to


### PR DESCRIPTION
The roadmap lists OAuth2 as \`Status: Future\` with no mention that
preliminary support already exists for IMAP/POP/SMTP via external scripts
(oauth2.py, mutt_oauth2.py), documented in
\`guide/optionalfeatures.html\`. Read as-is this looks like a flat
contradiction, but the roadmap entry specifically describes NeoMutt itself
natively managing the token flow — a genuinely different, still-unbuilt
thing from running an external script by hand.

Kept \`Status: Future\` (still accurate for the native implementation this
entry actually tracks) and added a short clarifying note distinguishing
the two, linking to the existing external-script docs.

AI disclosure: implemented with Claude Code's assistance.