### PR TITLE
docs: link real GitHub Discussions, point Donation at /sponsor

### DIFF
--- a/index.md
+++ b/index.md
@@ -65,10 +65,15 @@ When developing new features, the developers would love to benefit from your exp
 
 If an issue is labelled "type:discuss", then you're encouraged to offer your thoughts and opinions.
 
-### [Donation](https://www.paypal.me/russon/)
+### [GitHub Discussions](https://github.com/neomutt/neomutt/discussions)
+
+Got a more open-ended question or idea that doesn't fit an issue? Try our GitHub Discussions page.
+
+### [Donation](/sponsor)
 
 For the cost of a cup of coffee (or pint of beer :-)
-you could bring happiness into the life of NeoMutt creator [FlatCap](https://github.com/flatcap).
+you could bring happiness into the life of NeoMutt creator [FlatCap](https://github.com/flatcap) --
+or see the [sponsor page](/sponsor) for other ways to support the project.
 
 ## Twitter
 


### PR DESCRIPTION
Two separate gaps on the homepage:

1. The existing "Discussions" section links to an issue search filtered
   by the \`type:discuss\` label — a NeoMutt-specific convention, not
   GitHub's actual Discussions feature. Confirmed via the API that
   Discussions is enabled on neomutt/neomutt with 160 existing
   discussions, and nothing on the site links to it. Added a separate
   "GitHub Discussions" section rather than replacing the label-search
   one, since they serve different purposes.

2. The "Donation" section linked only to PayPal.me, but \`sponsor.md\`
   already lists GitHub Sponsors, Patreon, LiberaPay and BitCoin too.
   Pointed the heading at \`/sponsor\` and added a line mentioning the
   fuller sponsor page, rather than just swapping one payment link for
   another.

AI disclosure: implemented with Claude Code's assistance.