### PR TITLE
docs: fix two dead links found in the lychee link audit

### DIFF
--- a/_dev/analysis/coccinelle.md
+++ b/_dev/analysis/coccinelle.md
@@ -10,7 +10,7 @@ author: flatcap
 {{ page.description }}
 {% include analysis-links.html %}
 
-- [http://coccinelle.lip6.fr/](http://coccinelle.lip6.fr/)
+- [https://coccinelle.gitlabpages.inria.fr/website/](https://coccinelle.gitlabpages.inria.fr/website/)
 
 Coccinelle is a tool for manipulating C source code.  Because it really
 understands C, you can make complex changes, e.g.  If `x` is an integer,

--- a/_distro/exherbo.md
+++ b/_distro/exherbo.md
@@ -1,7 +1,7 @@
 ---
 distro: Exherbo Linux
 icon: exherbo.png
-homepage: https://git.exherbo.org/summer/packages/mail-client/neomutt/index.html
+homepage: https://gitlab.exherbo.org/exherbo/summer/-/tree/master/packages/mail-client/neomutt
 title: NeoMutt for Exherbo Linux
 maintainer: kdecherf
 ---


### PR DESCRIPTION
Found while scoping Phase P1 (link audit, tracked in a private roadmap, no public issue yet) using `lychee` against the raw Markdown/HTML source.

- `_dev/analysis/coccinelle.md`: `http://coccinelle.lip6.fr/` no longer resolves (connection refused). Coccinelle's site has moved to `coccinelle.gitlabpages.inria.fr`.
- `_distro/exherbo.md`: the `homepage` front-matter pointed at `git.exherbo.org`'s old cgit path, which now rejects the TLS handshake. Exherbo has migrated package browsing to `gitlab.exherbo.org`; same repo path under the new host, verified live.

Both replacement URLs checked directly (not just via the link checker) before making the change.