### PR TITLE
docs: fix moved iwyu mapping-file link

### DIFF
--- a/_dev/analysis/iwyu.md
+++ b/_dev/analysis/iwyu.md
@@ -72,7 +72,7 @@ with one helper header
 #include "mutt/mutt.h"
 ```
 
-The [mapping file](https://github.com/neomutt/iwyu/blob/main/neomutt.imp)
+The [mapping file](https://github.com/neomutt/iwyu/blob/main/imp/neomutt.imp)
 also provides fixes for some header files in glibc that cause confusion.
 It looks like this:
 


### PR DESCRIPTION
Found while scoping the CI-modernization phase on the main `neomutt/neomutt` repo (2026-07-24), confirmed again via the lychee link audit (2026-07-25) on this repo.

`github.com/neomutt/iwyu`'s `neomutt.imp` has moved from the repo root to `imp/neomutt.imp` — the repo itself is still active, not archived. This is P1-006 in a private roadmap tracking this repo's link audit.

Both paths checked directly before making the change: the new path returns 200, the old one 404s.