### PR TITLE
Remove Twitter/X icon and section (proposal, not a bug)

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -50,7 +50,6 @@
                   <img width="24" height="24" style="margin-right: 1em" src="/images/algolia.svg">
                   </li>
 
-                  <li class="active"><a title="Twitter" class="nav-link" href="https://twitter.com/NeoMutt_Org"><img width="32" height="32" alt="Twitter" src="/images/twitter.png"></a></li>
                   <li class="active"><a title="RSS Feed" class="nav-link" href="/feed.xml"><img width="24" height="24" alt="RSS" src="/images/rss.png"></a></li>
                   {% if site.github != '' %}
                   <li class="active"><a href="https://github.com/neomutt/neomutt"><img alt="stars" src="https://img.shields.io/github/stars/neomutt/neomutt.svg?style=social" /></a></li>

--- a/index.md
+++ b/index.md
@@ -75,10 +75,6 @@ For the cost of a cup of coffee (or pint of beer :-)
 you could bring happiness into the life of NeoMutt creator [FlatCap](https://github.com/flatcap) --
 or see the [sponsor page](/sponsor) for other ways to support the project.
 
-## Twitter
-
-We have a Twitter Feed [@NeoMutt_Org](https://twitter.com/NeoMutt_Org).
-
 ## Mailing lists
 
 We have two public mailing lists: <a class="rm" href="/2016/08/17/news">Read more...</a>


### PR DESCRIPTION
This is a proposal, not a bug fix — happy to close this if the project still wants the Twitter presence linked. Flagged in a private roadmap as a judgement call needing your steer rather than something to decide unilaterally.

The account (twitter.com/NeoMutt_Org) still resolves, so this isn't about a dead link — just whether it's still worth featuring in the header nav and homepage given X's changed reputation/ownership since this was added.

If NeoMutt has (or wants) a presence somewhere like Mastodon instead, happy to open a follow-up swapping this for that rather than just removing it outright.

AI disclosure: drafted with Claude Code's assistance, reviewed and sent by me.