### PR TITLE
docs: fix dev/deploy describing Travis CI despite its own title

### DIFF
--- a/_dev/deploy.md
+++ b/_dev/deploy.md
@@ -10,13 +10,18 @@ description: Update the website when certain builds succeed
 
 **Goal**: Update a web page when a certain branch is updated
 
+**This is how it actually works today**, via GitHub Actions:
+
 - User commits to the [translate](https://github.com/neomutt/neomutt/tree/translate) branch of the [neomutt](https://github.com/neomutt/neomutt) repo
-- Translation is checked
-- Update website:
-  * clone repo [neomutt.github.io](https://github.com/neomutt/neomutt.github.io)
-  * generate webpage
-  * commit webpage
-  * push to GitHub
+- [`translate.yml`](https://github.com/neomutt/neomutt/blob/main/.github/workflows/translate.yml) runs, using scripts from [neomutt/action-translate](https://github.com/neomutt/action-translate)
+- Translations are validated (`stats.sh`)
+- The webpage is generated (`generate-webpage.sh`) and committed straight to this repo's `main` branch, authenticated via a fine-grained deploy token (`secrets.TRANSLATE_DEPLOY_KEY`, scoped to this repo only)
+
+Every time a translator pushes an update, [the leaderboard](https://neomutt.org/translate) updates automatically — no manual steps, no SSH keys.
+
+## Historical: the original Travis CI setup
+
+The walkthrough below documents how this was originally set up, back when the project used Travis CI and authenticated via an SSH deploy key rather than a token. Travis CI is no longer used anywhere in NeoMutt's build pipeline — kept here for historical reference only, not as a guide to follow.
 
 Some names have been replaced in the examples below:
 


### PR DESCRIPTION
The page title says "Deployment using Actions", but the entire body only
ever documented the old Travis CI setup (SSH deploy key, `travis` gem,
`.travis.yml`), with dead links into the long-gone `translate` branch's
Travis config. Deployment has actually moved to GitHub Actions —
`translate.yml` + scripts from `neomutt/action-translate`, authenticated
via a fine-grained deploy token instead of an SSH key.

Added a factual summary of the current mechanism up top, linking to the
live workflow. Kept the original Travis walkthrough below a new
"Historical" heading rather than deleting it, matching the precedent set
in PR #140 (hard-problems.md).

AI disclosure: found and fixed with Claude Code's assistance, reviewed
and sent by me.