### PR TITLE
docs: fix mislabeled link and stale WIP framing on dev/support

### DIFF
--- a/_dev/support.md
+++ b/_dev/support.md
@@ -5,8 +5,10 @@ description: List of supported architectures / operating systems
 
 # {{ page.title }}
 
-**Note**: This is still work in progress and not at all fixed! For the
-discussion, see [#346](https://github.com/neomutt/neomutt/issues/436).
+**Note**: This page reflects a discussion that's since been resolved and closed — see
+[#436](https://github.com/neomutt/neomutt/issues/436) for the original conversation. The link
+text on this page previously read "#346" (an unrelated, closed IMAP issue) while actually
+pointing at #436 — fixed to match.
 
 ## Motivation
 


### PR DESCRIPTION
The visible link text read "#346" but the href actually pointed at
#436 — #346 is an unrelated, closed IMAP issue; #436 ("list of
architectures/operating systems mutt does run on") is the real
discussion this page is about. Both are long closed, so the "still
work in progress" framing was doubly stale on top of the mislabel.

AI disclosure: found and fixed with Claude Code's assistance, reviewed
and sent by me.