### PR TITLE
docs: fix repository list drift

### DIFF
--- a/_dev/github/repos.md
+++ b/_dev/github/repos.md
@@ -14,38 +14,29 @@ This is a list of all the Git repositories in the NeoMutt GitHub Project.
 | Repository                                                          | Description                                                                                              |
 | :------------------------------------------------------------------ | :------------------------------------------------------------------------------------------------------- |
 | [acutest](https://github.com/neomutt/acutest)                       | Simple (single header) C/C++ unit testing facility.                                                      |
-| [arch](https://github.com/neomutt/arch)                             | Ideas for a new mutt architecture                                                                        |
-| [aur-build](https://github.com/neomutt/aur-build)                   | Arch Linux User Repository for NeoMutt                                                                   |
-| [aur-docker](https://github.com/neomutt/aur-docker)                 | Docker image to test an AUR package build                                                                |
 | [autosetup](https://github.com/neomutt/autosetup)                   | A better, faster autoconf replacement                                                                    |
 | [coccinelle](https://github.com/neomutt/coccinelle)                 | Coccinelle Scripts                                                                                       |
 | [code](https://github.com/neomutt/code)                             | Doxygen docs auto-generated from the source code                                                         |
 | [completion-api](https://github.com/neomutt/completion-api)         | A new touch to the completion system of neomutt.                                                         |
-| [copr-neomutt](https://github.com/neomutt/copr-neomutt)             | Automated rpm builds for Fedora/RHEL                                                                     |
 | [corpus-address](https://github.com/neomutt/corpus-address)         | Test data for fuzzing                                                                                    |
 | [docbook](https://github.com/neomutt/docbook)                       | DocBook manual experiments                                                                               |
+| [fedora-copr](https://github.com/neomutt/fedora-copr)               | Automated rpm builds for Fedora/RHEL                                                                     |
 | [flatcap-brain-dump](https://github.com/neomutt/flatcap-brain-dump) | 4 years' worth of ideas -- unsorted and most likely meaningless to anyone but @flatcap                   |
-| [flatcap-vim](https://github.com/neomutt/flatcap-vim)               | Vim Syntax file for NeoMutt (work in progress)                                                           |
-| [gentoo-neomutt](https://github.com/neomutt/gentoo-neomutt)         | Automated builds for Gentoo                                                                              |
 | [gfx](https://github.com/neomutt/gfx)                               | Assorted images that don't have a home yet.                                                              |
 | [homebrew-core](https://github.com/neomutt/homebrew-core)           | Default formulae for the missing package manager for macOS                                               |
-| [homebrew-neomutt](https://github.com/neomutt/homebrew-neomutt)     | Automated builds for OS X                                                                                |
 | [lua-samples](https://github.com/neomutt/lua-samples)               | Sample C code to interact with LUA Scripts                                                               |
 | [management](https://github.com/neomutt/management)                 | Automation scripts and notes                                                                             |
 | [muttrc-mode-el](https://github.com/neomutt/muttrc-mode-el)         | Emacs major mode for editing muttrc                                                                      |
 | [neo-bot](https://github.com/neomutt/neo-bot)                       | IRC bot for #neomutt                                                                                     |
 | [neomutt-contrib](https://github.com/neomutt/neomutt-contrib)       | User Contributions to NeoMutt                                                                            |
-| [neomutt-docs](https://github.com/neomutt/neomutt-docs)             | Documentation for NeoMutt                                                                                |
 | [neomutt-old](https://github.com/neomutt/neomutt-old)               | Retired branches of NeoMutt                                                                              |
 | [neomutt-test-files](https://github.com/neomutt/neomutt-test-files) | Files and directories for NeoMutt's build test.                                                          |
 | [neomutt](https://github.com/neomutt/neomutt)                       | Teaching an Old Dog New Tricks -- IRC: #neomutt on irc.libera.chat
 | [neomutt.github.io](https://github.com/neomutt/neomutt.github.io)   | NeoMutt web pages                                                                                        |
 | [neomutt.vim](https://github.com/neomutt/neomutt.vim)               | vim syntax for neomuttrc                                                                                 |
-| [panel-manager](https://github.com/neomutt/panel-manager)           | Mock-up of a panel manager for mutt                                                                      |
 | [sample-data](https://github.com/neomutt/sample-data)               | Lists of things.  Useful for developing and testing.                                                     |
 | [sample-mail](https://github.com/neomutt/sample-mail)               | Sample mailboxes and config for testing                                                                  |
 | [samples](https://github.com/neomutt/samples)                       | Sample config                                                                                            |
-| [travis-build](https://github.com/neomutt/travis-build)             | Control the Travis builds more transparently                                                             |
 | [upstream-mutt](https://github.com/neomutt/upstream-mutt)           | Mirror of upstream Mutt                                                                                  |
 | [vim](https://github.com/neomutt/vim)                               | The official Vim repository                                                                              |
 
@@ -70,7 +61,16 @@ This is a list of all the Git repositories in the NeoMutt GitHub Project.
 
 | Repository                                                          | Description                                                                   |
 | :------------------------------------------------------------------ | :---------------------------------------------------------------------------- |
+| [aur-build](https://github.com/neomutt/aur-build)                   | Arch Linux User Repository for NeoMutt                                        |
+| [aur-docker](https://github.com/neomutt/aur-docker)                 | Docker image to test an AUR package build                                    |
 | [community](https://github.com/neomutt/community)                   | Birds-eye view of the Mutt Community                                          |
+| [flatcap-vim](https://github.com/neomutt/flatcap-vim)               | Vim Syntax file for NeoMutt (work in progress)                                |
+| [gentoo-neomutt](https://github.com/neomutt/gentoo-neomutt)         | Automated builds for Gentoo                                                   |
+| [homebrew-neomutt](https://github.com/neomutt/homebrew-neomutt)     | Automated builds for OS X                                                     |
 | [integration](https://github.com/neomutt/integration)               | Patch sets for downstream distros                                             |
+| [neomutt-docs](https://github.com/neomutt/neomutt-docs)             | Documentation for NeoMutt (superseded by `neomutt/docs`, docs.neomutt.org)    |
+| [panel-manager](https://github.com/neomutt/panel-manager)           | Mock-up of a panel manager for mutt                                          |
 | [release](https://github.com/neomutt/release)                       | How to make a NeoMutt Release                                                 |
 | [sidebar-history](https://github.com/neomutt/sidebar-history)       | Old versions of mutt-sidebar                                                  |
+| [test-arch](https://github.com/neomutt/test-arch)                   | Ideas for a new mutt architecture (renamed from `arch`)                      |
+| [travis-build](https://github.com/neomutt/travis-build)             | Control the Travis builds more transparently                                 |


### PR DESCRIPTION
neomutt/arch was renamed to neomutt/test-arch and archived in 2023 -
this page still listed it under the old name in the active table.

While fixing that, checked every other repo on this page against
live GitHub state (not just the one flagged) and found 8 more
archived repos still listed as active (aur-build, aur-docker,
flatcap-vim, gentoo-neomutt, homebrew-neomutt, neomutt-docs,
panel-manager, travis-build) plus one more rename (copr-neomutt ->
fedora-copr, still active). Moved the archived ones to the existing
"Archived Repos" section.

neomutt-docs is worth calling out specifically: it's the old
abandoned docs project, superseded by neomutt/docs
(docs.neomutt.org) - noted that in its description.

AI assistance: Claude Code drafted this change and PR description. I
verified every repo's archived/rename status against the GitHub API
directly before touching the page, rather than trusting the
roadmap's existing note at face value.