### PR TITLE
docs: point the Guide nav link at docs.neomutt.org

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -42,7 +42,7 @@
                   <li class="active"><a class="nav-link" href="/distro">Downloads</a></li>
                   <li class="active visible-xs-block"><a class="nav-link" href="/links">Links</a></li>
 
-                  <li class="active"><a class="nav-link" href="/guide/index">Guide</a></li>
+                  <li class="active"><a class="nav-link" href="https://docs.neomutt.org">Guide</a></li>
                   <li class="active"><a class="nav-link" href="/about">About</a></li>
 
                   <li class="active">

--- a/index.md
+++ b/index.md
@@ -30,6 +30,12 @@ Notably, the Sidebar patch has now been adopted by upstream Mutt.
 NeoMutt is available to download for various distros:
 [Read more...](distro.html)
 
+### Where's the documentation?
+
+{:.readmore}
+The full NeoMutt Guide -- installation, configuration, and reference -- lives at
+[docs.neomutt.org](https://docs.neomutt.org).
+
 ## I need help
 
 Oh, sorry to hear that. If you are a GitHub user, you can raise a


### PR DESCRIPTION
The top nav's "Guide" link still pointed at `/guide/index`, the old pre-rebuild manual — with no link to the new docs.neomutt.org anywhere on the homepage. The only documentation-adjacent link is a separate, easily-confused "Code Docs" sidebar link to code.neomutt.org (Doxygen source docs — a different thing entirely).

Repointed the nav link and added a short homepage-body mention alongside the existing Overview subsections.

**One thing I'm deliberately not deciding**: left the `/guide/` pages themselves untouched. Whether to keep them live under a legacy label, or remove them entirely, affects existing bookmarks and search-engine links — that's your call, not something to decide unilaterally. Happy to action either direction once you've picked one.

AI assistance: Claude Code investigated the nav/homepage structure and wrote this change. Reviewed before submitting.